### PR TITLE
Update secadm rules for ghc 8.0.2

### DIFF
--- a/ghc.rule
+++ b/ghc.rule
@@ -2,23 +2,10 @@ pax {
 	path: "/usr/local/lib/ghc-7.10.2/bin/ghc",
 	mprotect: false,
 },
+
 pax {
-	path: "/usr/local/lib/ghc-7.10.2/bin/ghc-pkg",
+	path: "/usr/local/lib/ghc-8.0.2/bin/ghc",
 	mprotect: false,
+	disallow_map32bit: false,
 },
-pax {
-	path: "/usr/local/lib/ghc-7.10.2/bin/haddock",
-	mprotect: false,
-},
-pax {
-	path: "/usr/local/lib/ghc-7.10.2/bin/hpc",
-	mprotect: false,
-},
-pax {
-	path: "/usr/local/lib/ghc-7.10.2/bin/hsc2hs",
-	mprotect: false,
-},
-pax {
-	path: "/usr/local/lib/ghc-7.10.2/bin/runghc",
-	mprotect: false,
-},
+


### PR DESCRIPTION
These rules will work for both ghc 7.10.2 and the newer 8.0.2.

While we're at it, I'm also removing unnecessary entries for ghc-pkg, haddock, hpc, hsc2hs and runghc. They appear to be running just fine with mprotect enabled. (Please correct me if I'm wrong.)